### PR TITLE
Fixed #26223 -- Fixed migration optimizer for operations with transient defaults.

### DIFF
--- a/tests/migrations/test_autodetector.py
+++ b/tests/migrations/test_autodetector.py
@@ -697,7 +697,7 @@ class AutodetectorTests(TestCase):
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, 'testapp', 1)
         self.assertOperationTypes(changes, 'testapp', 0, ["AlterField"])
-        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=True)
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", default=models.NOT_PROVIDED)
 
     def test_supports_functools_partial(self):
         def _content_file_name(instance, filename, key, **kwargs):
@@ -759,7 +759,7 @@ class AutodetectorTests(TestCase):
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, 'testapp', 1)
         self.assertOperationTypes(changes, 'testapp', 0, ["AlterField"])
-        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=True)
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", default=models.NOT_PROVIDED)
         self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default='Ada Lovelace')
 
     @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_not_null_alteration',
@@ -773,7 +773,7 @@ class AutodetectorTests(TestCase):
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, 'testapp', 1)
         self.assertOperationTypes(changes, 'testapp', 0, ["AlterField"])
-        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=True)
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", default=models.NOT_PROVIDED)
         self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default=models.NOT_PROVIDED)
 
     @mock.patch('django.db.migrations.questioner.MigrationQuestioner.ask_not_null_alteration',
@@ -787,8 +787,8 @@ class AutodetectorTests(TestCase):
         # Right number/type of migrations?
         self.assertNumberMigrations(changes, 'testapp', 1)
         self.assertOperationTypes(changes, 'testapp', 0, ["AlterField"])
-        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", preserve_default=False)
-        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default="Some Name")
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="name", default="Some Name")
+        self.assertOperationFieldAttributes(changes, "testapp", 0, 0, default=models.NOT_PROVIDED)
 
     def test_rename_field(self):
         """Tests autodetection of renamed fields."""

--- a/tests/migrations/test_operations.py
+++ b/tests/migrations/test_operations.py
@@ -947,18 +947,18 @@ class OperationTests(OperationTestBase):
             operation.database_forwards("test_regr22168", editor, project_state, new_state)
         self.assertColumnExists("test_regr22168_pony", "order")
 
-    def test_add_field_preserve_default(self):
+    def test_add_field_default(self):
         """
         Tests the AddField operation's state alteration
-        when preserve_default = False.
+        when default is given.
         """
         project_state = self.set_up_test_model("test_adflpd")
         # Test the state alteration
         operation = migrations.AddField(
             "Pony",
             "height",
-            models.FloatField(null=True, default=4),
-            preserve_default=False,
+            models.FloatField(null=True),
+            default=4,
         )
         new_state = project_state.clone()
         operation.state_forwards("test_adflpd", new_state)
@@ -980,7 +980,7 @@ class OperationTests(OperationTestBase):
         definition = operation.deconstruct()
         self.assertEqual(definition[0], "AddField")
         self.assertEqual(definition[1], [])
-        self.assertEqual(sorted(definition[2]), ["field", "model_name", "name", "preserve_default"])
+        self.assertEqual(sorted(definition[2]), ["default", "field", "model_name", "name"])
 
     def test_add_field_m2m(self):
         """

--- a/tests/migrations/test_optimizer.py
+++ b/tests/migrations/test_optimizer.py
@@ -3,6 +3,7 @@
 from django.db import migrations, models
 from django.db.migrations import operations
 from django.db.migrations.optimizer import MigrationOptimizer
+from django.db.migrations.serializer import serializer_factory
 from django.test import SimpleTestCase
 
 from .models import EmptyManager, UnicodeModel
@@ -20,10 +21,13 @@ class OptimizerTests(SimpleTestCase):
         optimizer = MigrationOptimizer()
         return optimizer.optimize(operations, app_label), optimizer._iterations
 
+    def serialize(self, value):
+        return serializer_factory(value).serialize()[0]
+
     def assertOptimizesTo(self, operations, expected, exact=None, less_than=None, app_label=None):
         result, iterations = self.optimize(operations, app_label)
-        result = [repr(f.deconstruct()) for f in result]
-        expected = [repr(f.deconstruct()) for f in expected]
+        result = [self.serialize(f) for f in result]
+        expected = [self.serialize(f) for f in expected]
         self.assertEqual(expected, result)
         if exact is not None and iterations != exact:
             raise self.failureException(
@@ -694,5 +698,93 @@ class OptimizerTests(SimpleTestCase):
             ],
             [
                 migrations.CreateModel("Phou", [("name", models.CharField(max_length=255))]),
+            ],
+        )
+
+    def test_default_create_model_add_field(self):
+        """
+        AddField optimizing into CreateModel should drop default if
+        preserve_default is False.
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel("Foo", [("name", models.CharField(max_length=255))]),
+                migrations.AddField("Foo", "value", models.IntegerField(default=42), preserve_default=False),
+            ],
+            [
+                migrations.CreateModel("Foo", [
+                    ("name", models.CharField(max_length=255)),
+                    ("value", models.IntegerField()),
+                ]),
+            ],
+        )
+
+    def test_default_create_model_alter_field(self):
+        """
+        AlterField optimizing into CreateModel should drop default if
+        preserve_default is False.
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.CreateModel("Foo", [("value", models.IntegerField(null=True))]),
+                migrations.AlterField("Foo", "value", models.IntegerField(default=42), preserve_default=False),
+            ],
+            [
+                migrations.CreateModel("Foo", [("value", models.IntegerField())]),
+            ],
+        )
+
+    def test_default_add_field_alter_field(self):
+        """
+        AddField and AlterField optimizing when one of them has
+        preserve_default=False should pass the preserve_default value.
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.AddField("Foo", "value", models.IntegerField(null=True)),
+                migrations.AlterField("Foo", "value", models.IntegerField(default=42), preserve_default=False),
+            ],
+            [
+                migrations.AddField("Foo", "value", models.IntegerField(default=42), preserve_default=False),
+            ],
+        )
+        self.assertOptimizesTo(
+            [
+                migrations.AddField("Foo", "value", models.IntegerField(default=42), preserve_default=False),
+                migrations.AlterField("Foo", "value", models.IntegerField("Value")),
+            ],
+            [
+                migrations.AddField("Foo", "value", models.IntegerField("Value", default=42), preserve_default=False),
+            ],
+        )
+
+    def test_default_add_field_rename_field(self):
+        """
+        AddField optimizing with RenameField should retain its
+        preserve_default value.
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.AddField("Foo", "value", models.IntegerField(default=42), preserve_default=False),
+                migrations.RenameField("Foo", "value", "price"),
+            ],
+            [
+                migrations.AddField("Foo", "price", models.IntegerField(default=42), preserve_default=False),
+            ],
+        )
+
+    def test_default_alter_field_rename_field(self):
+        """
+        AlterField optimizing with RenameField should retain its
+        preserve_default value.
+        """
+        self.assertOptimizesTo(
+            [
+                migrations.AlterField("Foo", "value", models.IntegerField(default=42), preserve_default=False),
+                migrations.RenameField("Foo", "value", "price"),
+            ],
+            [
+                migrations.RenameField("Foo", "value", "price"),
+                migrations.AlterField("Foo", "price", models.IntegerField(default=42), preserve_default=False),
             ],
         )


### PR DESCRIPTION
One-off defaults for fields are now stored on the operation instead of
the operation having a preserve_default flag.
